### PR TITLE
workaround for initial messages form content script not being delivered

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,5 +16,10 @@
   "packageManager": "pnpm@9.0.0",
   "engines": {
     "node": ">=18"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "webext-bridge": "patches/webext-bridge.patch"
+    }
   }
 }

--- a/patches/webext-bridge.patch
+++ b/patches/webext-bridge.patch
@@ -1,0 +1,25 @@
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+deleted file mode 100644
+index 6e87c8895a7af535c8fc7f6b9f5ac3c06c30e0b7..0000000000000000000000000000000000000000
+diff --git a/dist/chunk-E2HJRHOS.js b/dist/chunk-E2HJRHOS.js
+index 64e4fcda25d0664c036ec2176403f231d5047ff7..2b1600046b408d6f4f46fcddaafa039c1c360870 100644
+--- a/dist/chunk-E2HJRHOS.js
++++ b/dist/chunk-E2HJRHOS.js
+@@ -17,7 +17,7 @@ var createPersistentPort = (name = "") => {
+   const handleMessage = (msg, port2) => {
+     switch (msg.status) {
+       case "undeliverable":
+-        if (!undeliveredQueue.some((m) => m.message.messageID === msg.message.messageID)) {
++        // if (!undeliveredQueue.some((m) => m.message.messageID === msg.message.messageID)) {
+           undeliveredQueue = [
+             ...undeliveredQueue,
+             {
+@@ -25,7 +25,7 @@ var createPersistentPort = (name = "") => {
+               resolvedDestination: msg.resolvedDestination
+             }
+           ];
+-        }
++        // }
+         return;
+       case "deliverable":
+         undeliveredQueue = undeliveredQueue.reduce((acc, queuedMsg) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  webext-bridge:
+    hash: iabrmmoep4vc2klod3crpscc2q
+    path: patches/webext-bridge.patch
+
 importers:
 
   .:
@@ -55,7 +60,7 @@ importers:
         version: 1.0.7(tailwindcss@3.4.17)
       webext-bridge:
         specifier: ^6.0.1
-        version: 6.0.1
+        version: 6.0.1(patch_hash=iabrmmoep4vc2klod3crpscc2q)
     devDependencies:
       '@types/chrome':
         specifier: ^0.0.309
@@ -7617,7 +7622,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webext-bridge@6.0.1:
+  webext-bridge@6.0.1(patch_hash=iabrmmoep4vc2klod3crpscc2q):
     dependencies:
       '@types/webextension-polyfill': 0.8.3
       nanoevents: 6.0.2


### PR DESCRIPTION
this has a downsite, even though we deliver JSTC events, we will miss network events because `browser.devtools.network` listeners will be attached too late